### PR TITLE
Add get_process_name

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -186,6 +186,8 @@ register_cfunctions(lua_State *lua)
 	lua_register(lua, "xywh", c_xywh);
 
 	lua_register(lua, "on_geometry_changed", c_on_geometry_changed);
+
+    lua_register(lua, "get_process_name", c_get_process_name);
 }
 
 

--- a/src/script_functions.h
+++ b/src/script_functions.h
@@ -126,4 +126,6 @@ int c_xywh(lua_State *lua);
 
 int c_on_geometry_changed(lua_State *lua);
 
+int c_get_process_name(lua_State *lua);
+
 #endif /*__HEADER_SCRIPT_FUNCTIONS_*/


### PR DESCRIPTION
Adds a LUA function get_process_name implemented in c_get_process_name that retrieves the binary name of the process of the window by its PID which is retrieved through wnck_window_get_pid.
It uses a shell command "ps c %d | tail -n 1 | awk '{print $5}'" where %d is the PID.
A better approach would be using "/proc/%d/cmdline" however this includes the whole path and all command arguments which would first have to be cleaned up to be usable, however my C skills are too low to do this.
Some windows, like the Steam Friends window, return 0 as PID so this is not a complete solution.

The reason this function is useful is because many programs change their window name and application name, like Discord (depending on the chat that is open) or Spotify (depending on the active song).
Other programs also report "Unnamed window" as their window and application name, like Spotify upon startup, making it impossible to correctly identify a program just by their window or application name.

Again, my C skills suck, so please feel free to improve this functionality!