### PR TITLE
Implement on window title change hook + README revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ First, a function to show some debug info
 
 `debug_print(string)`
 
-   Debug helper that prints a string to stdout. The string is only printed to
-   stdout if `devilspie2` is run with the `--debug` option, otherwise nothing will
-   be printed.
+    Debug helper that prints a string to stdout. The string is only printed to
+    stdout if `devilspie2` is run with the `--debug` option, otherwise nothing will
+    be printed.
 
 
 
@@ -97,81 +97,88 @@ information:
 
 `get_window_name()`
 
-   Returns a string containing the name of the current window.
+    Returns a string containing the name of the current window.
 
 
 `get_window_has_name()`
 
-   Return true or false depending on if the window has a name or not
-   (Available from version 0.20)
+    Return true or false depending on if the window has a name or not
+**(Available from version 0.20)**
 
 
 `get_application_name()`
 
-   Returns the application name of the current window.
+    Returns the application name of the current window.
 
 
 `get_process_name()`
 
-   Returns the name of the process owning the current window.
+    Returns the name of the process owning the current window.
 
-   On (at least) Linux, the process name is read from /proc/<pid>/comm. If
-   that's not possible, 'ps' is launched in a shell. For this reason, you
-   should avoid calling get_process_name() more than necessary.
+    On (at least) Linux, the process name is read from /proc/<pid>/comm. If
+    that's not possible, 'ps' is launched in a shell. For this reason, you
+    should avoid calling get_process_name() more than necessary.
 
-   This function is not compatible with busybox ps.
+    This function is not compatible with busybox ps.
 
-   (Available from version 0.44)
+**(Available from version 0.44)**
 
 
 `get_window_geometry()`
 
-   Returns the window geometry as four numbers - x-position, y-position,
-   width and height. (from version 0.16) - for example you can do something
-	like this:
+    Returns the window geometry as four numbers - x-position, y-position,
+    width and height. (from version 0.16) - for example you can do something
+    like this:
 
-	x, y, width, height = get_window_geometry();
-	print("X: "..x..", Y: "..y..", width: "..width..", height: "..height);
+    x, y, width, height = get_window_geometry();
+    print("X: "..x..", Y: "..y..", width: "..width..", height: "..height);
 
 
 `get_window_client_geometry()`
 
-   Returns the window geometry excluding the window manager borders as four
-   numbers, x-position, y-position, width and height. (from version 0.16) -
-	see `get_window_geometry()` for an example on how to use this function.
+    Returns the window geometry excluding the window manager borders as four
+    numbers, x-position, y-position, width and height. (from version 0.16) -
+    see `get_window_geometry()` for an example on how to use this function.
 
 
-`get_window_is_maximized()`
-`get_window_is_maximised()`
+```
+get_window_is_maximized()
+get_window_is_maximised()
+```
 
-   Returns true if the window is maximised, false otherwise. (available from
-   version 0.21; -ise from 0.45)
-
-
-`get_window_is_maximized_vertically()`
-`get_window_is_maximised_vertically()`
-
-   Returns true if the window is vertically maximised, false otherwise.
-   (available from version 0.21; -ise from 0.45)
+    Returns true if the window is maximised, false otherwise. 
+**(Available from version 0.21; -ise from 0.45)**
 
 
-`get_window_is_maximized_horizontally()`
-`get_window_is_maximised_horizontally()`
+```
+get_window_is_maximized_vertically()
+get_window_is_maximised_vertically()
+```
 
-   Returns true if the window is horizontally maximised, false otherwise.
-   (available from version 0.21; -ise from 0.45)
+    Returns true if the window is vertically maximised, false otherwise.
+**(Available from version 0.21; -ise from 0.45)**
+
+
+```
+get_window_is_maximized_horizontally()
+get_window_is_maximised_horizontally()
+```
+
+    Returns true if the window is horizontally maximised, false otherwise.
+**(Available from version 0.21; -ise from 0.45)**
 
 
 `get_window_is_decorated()`
 
-   Returns true if the window is decorated, false otherwise.
-   (Available from version 0.44.)
+    Returns true if the window is decorated, false otherwise.
+    
+**(Available from version 0.44)**
 
 
 `get_window_type()`
 
-   Returns the type of the window - The result type is a string, and can
-   be one of the following:
+    Returns the type of the window - The result type is a string, and can
+    be one of the following:
 ```
    "WINDOW_TYPE_NORMAL"
    "WINDOW_TYPE_DESKTOP"
@@ -187,7 +194,7 @@ information:
    If, for whatever reason, the function didn't have a window to work on,  
    `WINDOW_ERROR` will be returned.
 
-   (Available from version 0.21)
+**(Available from version 0.21)**
 
 
 `get_class_instance_name()`
@@ -210,7 +217,7 @@ information:
 
    From 0.45, returns nil if the property doesn't exist.
 
-   (Available from version 0.21)
+**(Available from version 0.21)**
 
 
 `get_window_role()`
@@ -251,7 +258,8 @@ information:
 
    Returns the index of the monitor containing the window centre (or some
    part of the window).
-   (Available from version 0.44)
+
+**(Available from version 0.44)**
 
 
 `get_monitor_geometry()`
@@ -365,43 +373,55 @@ The rest of the functions are used to modify the properties of the windows:
    Un-shades a window - the opposite of "shade"
 
 
-`maximize()`
-`maximise()`
+```
+maximize()
+maximise()
+```
 
-   Maximises a window
-   (-ise from 0.45)
-
-
-`unmaximize()`
-`unmaximise()`
-
-   Un-maximises a window
-   (-ise from 0.45)
+    Maximises a window
+    (-ise from 0.45)
 
 
-`maximize_vertically()`
-`maximise_vertically()`
+```
+unmaximize()
+unmaximise()
+```
+    
+    Un-maximises a window
+    (-ise from 0.45)
+
+
+```
+maximize_vertically()
+maximise_vertically()
+```
 
    Maximises the current window vertically.
    (-ise from 0.45)
 
 
-`maximize_horizontally()`
-`maximise_horizontally()`
+```
+maximize_horizontally()
+maximise_horizontally()
+```
 
    Maximises the current window horizontally.
    (-ise from 0.45)
 
 
-`minimize()`
-`minimise()`
+```
+minimize()
+minimise()
+```
 
    Minimises a window
    (-ise from 0.45)
 
 
-`unminimize()`
-`unminimise()`
+```
+unminimize()
+unminimise()
+```
 
    Un-minimises a window, that is bringing it back to screen from the minimised
    position/size.
@@ -518,8 +538,10 @@ The rest of the functions are used to modify the properties of the windows:
 	where in the viewport the window will be placed.
 	(Available from version 0.40)
 
-`center([index,] [direction])`
-`centre([index,] [direction])`
+```
+center([index,] [direction])
+centre([index,] [direction])
+```
 
    With no parameters, centres the current window on the current workspace.
    May place the window across multiple monitors.
@@ -548,8 +570,10 @@ The rest of the functions are used to modify the properties of the windows:
    (Parameters and ‘centre’ available from version 0.44)
 
 
-`set_opacity(value)`
-`set_window_opacity(value)`
+```
+set_opacity(value)
+set_window_opacity(value)
+```
 
 	Sets the window opacity, takes a float value, 1.0 = completely opaque,
 	0.0, completely see-through. Both set_opacity and set_window_opacity
@@ -561,7 +585,7 @@ The rest of the functions are used to modify the properties of the windows:
 
 	Sets the window type, according to `_NET_WM_WINDOW_TYPE`. The allowed types
 	are the standard `_NET_WM` ones (formatted as a string):
-```
+
 	"_NET_WM_WINDOW_TYPE_DESKTOP"
 	"_NET_WM_WINDOW_TYPE_DOCK"
 	"_NET_WM_WINDOW_TYPE_TOOLBAR"
@@ -570,9 +594,9 @@ The rest of the functions are used to modify the properties of the windows:
 	"_NET_WM_WINDOW_TYPE_SPLASH"
 	"_NET_WM_WINDOW_TYPE_DIALOG"
 	"_NET_WM_WINDOW_TYPE_NORMAL"
-```
+
 	or shorter versions of the same values
-```
+
 	"WINDOW_TYPE_DESKTOP"
 	"WINDOW_TYPE_DOCK"
 	"WINDOW_TYPE_TOOLBAR"
@@ -581,11 +605,13 @@ The rest of the functions are used to modify the properties of the windows:
 	"WINDOW_TYPE_SPLASH"
 	"WINDOW_TYPE_DIALOG"
 	"WINDOW_TYPE_NORMAL"
-```
-	(Function is available from version 0.28)
+	
+**(Available from version 0.28)**
 
-`focus()`
-`focus_window()`
+```
+focus()
+focus_window()
+```
 
 	Focuses the current window. (Function is available from version 0.30)
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ by the `--folder` option. By default this folder is `~/.config/devilspie2/`.
 
 If there is a file named `devilspie2.lua` in this folder, it is read and it is
 searched for a variable (a Lua table of strings) named 
-`scripts_window_close`, `scripts_window_focus` or `scripts_window_blur`.
+`scripts_window_close`, `scripts_window_focus`, `scripts_window_blur` 
+or `scripts_window_title_change`. 
 The filenames in the strings in this table will be called when windows are
 closed, focused or blurred respectively. If these variables aren't present in
 the file, it will be called as a `devilspie2` script file like any other.
@@ -59,8 +60,17 @@ scripts_window_close = {
 }
 ```
 
-This would make the files `file1.lua` and `file2.lua` interpreted when windows are
+The above would make the files `file1.lua` and `file2.lua` interpreted when windows are
 closing.
+
+```lua
+scripts_window_title_change = {
+    "window_title_change.lua"
+}
+```
+
+This will invoke `window_title_change.lua` when the window's title changes.
+
 
 
 ## Scripting

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ the file, it will be called as a `devilspie2` script file like any other.
 
 For example:
 
-```lue
+```lua
 scripts_window_close = {
    "file1.lua",
    "file2.lua"
@@ -179,7 +179,7 @@ get_window_is_maximised_horizontally()
 
     Returns the type of the window - The result type is a string, and can
     be one of the following:
-```
+
    "WINDOW_TYPE_NORMAL"
    "WINDOW_TYPE_DESKTOP"
    "WINDOW_TYPE_DOCK"
@@ -188,7 +188,7 @@ get_window_is_maximised_horizontally()
    "WINDOW_TYPE_MENU"
    "WINDOW_TYPE_UTILITY"
    "WINDOW_TYPE_SPLASHSCREEN"
-```
+
    or `WINDOW_TYPE_UNRECOGNIZED` if libwnck didn't recognise the type.
 
    If, for whatever reason, the function didn't have a window to work on,  
@@ -256,22 +256,23 @@ get_window_is_maximised_horizontally()
 
 `get_monitor_index()`
 
-   Returns the index of the monitor containing the window centre (or some
-   part of the window).
+    Returns the index of the monitor containing the window centre (or some
+    part of the window).
 
 **(Available from version 0.44)**
 
 
 `get_monitor_geometry()`
 
-   Returns x, y, width, height for the window's monitor.
-   (Available from version 0.44)
+    Returns x, y, width, height for the window's monitor.
+    
+**(Available from version 0.44)**
 
 
 `get_monitor_geometry(index)`
 
-   Returns x, y, width, height for the given monitor.
-   If the index is out of range, nothing is returned.
+    Returns x, y, width, height for the given monitor.
+    If the index is out of range, nothing is returned.
 
 
 The rest of the functions are used to modify the properties of the windows:
@@ -279,306 +280,289 @@ The rest of the functions are used to modify the properties of the windows:
 
 `set_adjust_for_decoration([bool])`
 
-   Allow for situations where moving or resizing the window is done
-   incorrectly, i.e.
-      `set_window_position(0,0)`
-   results in the window decoration being taken into account twice, i.e. 
-   the window (including decoration) is offset from the top left corner by
-   the width of the left side decoration and the height of the title bar.
+    Allow for situations where moving or resizing the window is done
+    incorrectly, i.e.
+        `set_window_position(0,0)`
+    results in the window decoration being taken into account twice, i.e. 
+    the window (including decoration) is offset from the top left corner by
+    the width of the left side decoration and the height of the title bar.
 
-   This is currently off by default, and is sticky: if you do not explicitly
-   set it in your script, its current value is retained.
+    This is currently off by default, and is sticky: if you do not explicitly
+    set it in your script, its current value is retained.
 
-   If used, it should be used at the start of the script.
+    If used, it should be used at the start of the script.
 
-   This affects the following functions:
-```
+    This affects the following functions:
+
       set_window_geometry()
       set_window_position()
       set_window_size()
       xy()
       xywh()
-```
-   (Available from version 0.45)
+
+**(Available from version 0.45)**
 
 
 `set_window_position(xpos, ypos, [index])`
 
-   Set the position of a window.
+    Set the position of a window.
 
-   If index is specified then the co-ordinates are relative to a corner of
-   the specified monitor (counting from 1) on the current workspace. Which
-   corner is determined by the co-ordinates' signs:
-      `+ve X ⇒ left, -ve X ⇒ right;`
-      `+ve Y ⇒ top,  -ve Y ⇒ bottom.`
+    If index is specified then the co-ordinates are relative to a corner of
+    the specified monitor (counting from 1) on the current workspace. Which
+    corner is determined by the co-ordinates' signs:
+        `+ve X ⇒ left, -ve X ⇒ right;`
+        `+ve Y ⇒ top,  -ve Y ⇒ bottom.`
 
-   NOTE: since -0 would have a use here but is equal to +0, ~ (bitwise NOT)
-   is used. To put the window 60px from the right or bottom, use ~60 or -61.
+    NOTE: since -0 would have a use here but is equal to +0, ~ (bitwise NOT)
+    is used. To put the window 60px from the right or bottom, use ~60 or -61.
 
-   If index = 0 then the ‘current’ monitor (with the window's centre point)
-   is used (falling back on then the first monitor showing part of the
-   window then the first monitor).
+    If index = 0 then the ‘current’ monitor (with the window's centre point)
+    is used (falling back on then the first monitor showing part of the
+    window then the first monitor).
 
-   If index = -1 then all monitors are treated as one large virtual monitor.
+    If index = -1 then all monitors are treated as one large virtual monitor.
 
 
 `set_window_position2(xpos, ypos)`
 
-   Set the position of a window - unlike `set_window_position()`, this
-   function uses `XMoveWindow` instead of `wnck_window_set_geometry()` which
-   gives a slightly different result.
-   (Available from version 0.21)
+    Set the position of a window - unlike `set_window_position()`, this
+    function uses `XMoveWindow` instead of `wnck_window_set_geometry()` which
+    gives a slightly different result.
+
+**(Available from version 0.21)**
 
 
 `set_window_property(property, value)`
 
-   Set a property of a window to a string or a cardinal (32-bit integer or
-   boolean).
-   (Available from version 0.44)
+    Set a property of a window to a string or a cardinal (32-bit integer or
+    boolean).
+    
+**(Available from version 0.44)**
 
 
 `delete_window_property(property)`
 
-   Remove a property from a window.
-   (Available from version 0.44)
+    Remove a property from a window.
+   
+**(Available from version 0.44)**
 
 
 `set_window_size (xsize, ysize)`
 
-   Sets the size of a window - takes `xsize` and `ysize` as parameters.
+    Sets the size of a window - takes `xsize` and `ysize` as parameters.
 
 
 `set_window_geometry (xpos, ypos, xsize, ysize)`
 
-   Sets both size and position of a window in one command. Takes four
-   parameters, `xpos`, `ypos`, `xsize` and `ysize`.
+    Sets both size and position of a window in one command. Takes four
+    parameters, `xpos`, `ypos`, `xsize` and `ysize`.
 
 
 `set_window_geometry2 (xpos, ypos, xsize, ysize)`
 
-   Sets the window geometry just as `set_window_geometry()`, using
-   `XMoveResizeWindow()` instead of its `libwnck` alternative. This results in
-   different coordinates than the `set_window_geometry()` function, and results
-   are more similar to the results of the original `devilspie` geometry function.
-   (available from version 0.21)
+    Sets the window geometry just as `set_window_geometry()`, using
+    `XMoveResizeWindow()` instead of its `libwnck` alternative. This results in
+    different coordinates than the `set_window_geometry()` function, and results
+    are more similar to the results of the original `devilspie` geometry function.
+    (available from version 0.21)
 
 
 `shade()`
 
-   "Shades" a window, showing only the title-bar.
+    "Shades" a window, showing only the title-bar.
 
 
 `unshade()`
 
-   Un-shades a window - the opposite of "shade"
+    Un-shades a window - the opposite of "shade"
 
 
-```
-maximize()
-maximise()
-```
+`maximize(), maximise()`
 
     Maximises a window
     (-ise from 0.45)
 
 
-```
-unmaximize()
-unmaximise()
-```
+`unmaximize(), unmaximise()`
     
     Un-maximises a window
     (-ise from 0.45)
 
 
-```
-maximize_vertically()
-maximise_vertically()
-```
+`maximize_vertically(), maximise_vertically()`
 
-   Maximises the current window vertically.
-   (-ise from 0.45)
+    Maximises the current window vertically.
+    (-ise from 0.45)
 
 
-```
-maximize_horizontally()
-maximise_horizontally()
-```
+`maximize_horizontally(), maximise_horizontally()`
 
-   Maximises the current window horizontally.
-   (-ise from 0.45)
+    Maximises the current window horizontally.
+    (-ise from 0.45)
 
 
-```
-minimize()
-minimise()
-```
+`minimize(), minimise()`
 
-   Minimises a window
-   (-ise from 0.45)
+    Minimises a window.
+    (-ise from 0.45)
 
 
-```
-unminimize()
-unminimise()
-```
+`unminimize(), unminimise()`
 
-   Un-minimises a window, that is bringing it back to screen from the minimised
-   position/size.
-   (-ise from 0.45)
+    Un-minimises a window, that is bringing it back to screen from the minimised
+    position/size.
+    (-ise from 0.45)
 
 
 `decorate_window()`
 
-   Shows all window decoration.
+    Shows all window decoration.
 
 
 `undecorate_window()`
 
-   Removes all window decorations.
+    Removes all window decorations.
 
 
 `close_window()`
 
-	Closes the window. (Available from 0.31)
+    Closes the window. (Available from 0.31)
 
 
 `set_window_workspace(number)`
 
-   Moves a window to another workspace. The number variable starts counting at
-   1.
+    Moves a window to another workspace. The number variable starts counting at
+    1.
 
 
 `change_workspace(number)`
 
-   Changes the current workspace to another. The number variable starts counting
-   at 1.
+    Changes the current workspace to another. The number variable starts counting
+    at 1.
 
 
 `pin_window()`
 
-   Asks the window manager to put the window on all workspaces.
+    Asks the window manager to put the window on all workspaces.
 
 
 `unpin_window()`
 
-   Asks the window manager to put window only in the currently active workspace.
+    Asks the window manager to put window only in the currently active workspace.
 
 
 `stick_window()`
 
-   Asks the window manager to keep the window's position fixed on the screen,
-   even when the workspace or viewport scrolls.
+    Asks the window manager to keep the window's position fixed on the screen,
+    even when the workspace or viewport scrolls.
 
 
 `unstick_window()`
 
-   Asks the window manager to not have window's position fixed on the screen
-   when the workspace or viewport scrolls.
+    Asks the window manager to not have window's position fixed on the screen
+    when the workspace or viewport scrolls.
 
 
 `set_skip_tasklist(skip)`
 
-   Set this to true if you would like the window to skip listing in your
-   tasklist. Takes a boolean(true or false) as value. (from version 0.16)
+    Set this to true if you would like the window to skip listing in your
+    tasklist. Takes a boolean(true or false) as value. (from version 0.16)
 
 
 `set_skip_pager(skip)`
 
-   Set this to true if you would like the window to skip listing in your pager.
-   Takes a boolean(true or false) as value. (from version 0.16)
+    Set this to true if you would like the window to skip listing in your pager.
+    Takes a boolean(true or false) as value. (from version 0.16)
 
 
 `set_window_above([above])`
 
-   Set the current window above all normal windows. (available from version
-   0.21)
-   Optionally takes a boolean(true or false) as value.
+    Set the current window above all normal windows. (available from version
+    0.21)
+    Optionally takes a boolean(true or false) as value.
 
-  `make_always_on_top()` is the same as `set_window_above(true)`.
+    `make_always_on_top()` is the same as `set_window_above(true)`.
 
 
 `set_on_top()`
 
-   sets a window on top of the others.
-   Unlike `set_window_above()`, it doesn't lock the window in this position.
-   As of version 0.45, the window's layer (above, between, below) is
-   maintained.
+    sets a window on top of the others.
+    Unlike `set_window_above()`, it doesn't lock the window in this position.
+    As of version 0.45, the window's layer (above, between, below) is
+    maintained.
 
 
 `set_window_below([below])`
 
-   Set the current window below all normal windows. (available from version
-   0.21)
-   Optionally takes a boolean(true or false) as value.
+    Set the current window below all normal windows. 
+    Optionally takes a boolean(true or false) as value.
+
+**(available from version 0.21)**
 
 
 `set_on_bottom()`
 
-   Sets a window below the others.
-   Unlike `set_window_below()`, it doesn't lock the window in this position.
-   (Available from version 0.45.)
+    Sets a window below the others.
+    Unlike `set_window_below()`, it doesn't lock the window in this position.
+
+**(Available from version 0.45.)**
 
 
 `set_window_fullscreen(fullscreen)`
 
-   Asks the window manager to set the fullscreen state of the window according
-   to the fullscreen boolean. (available from version 0.24)
+    Asks the window manager to set the fullscreen state of the window according
+    to the fullscreen boolean. (available from version 0.24)
 
 
 `set_viewport(viewport)`
 
-   Using one indata, moves the window to the requested viewport - Counting
-	starts at number 1. (Available from version 0.25)
-	- Also see the alternative usage of this function below.
+    Using one indata, moves the window to the requested viewport - Counting
+    starts at number 1. (Available from version 0.25)
+    Also see the alternative usage of this function below.
 
 `set_viewport(x, y)`
 
-	If you are using two indata to the set_viewport function, you can decide
-	where in the viewport the window will be placed.
-	(Available from version 0.40)
+    If you are using two indata to the set_viewport function, you can decide
+    where in the viewport the window will be placed.
 
-```
-center([index,] [direction])
-centre([index,] [direction])
-```
+**(Available from version 0.40)**
 
-   With no parameters, centres the current window on the current workspace.
-   May place the window across multiple monitors.
+`center([index,] [direction]), centre([index,] [direction])`
 
-   If index is specified, centres the current window on the specified
-   monitor (counting from 1) on the current workspace.
+    With no parameters, centres the current window on the current workspace.
+    May place the window across multiple monitors.
 
-   If index = 0 then the ‘current’ monitor (with the window's centre point)
-   is used (falling back on then the first monitor showing part of the
-   window then the first monitor).
+    If index is specified, centres the current window on the specified
+    monitor (counting from 1) on the current workspace.
 
-   If index = -1 then all monitors are treated as one large virtual monitor.
+    If index = 0 then the ‘current’ monitor (with the window's centre point)
+    is used (falling back on then the first monitor showing part of the
+    window then the first monitor).
 
-   If index is out of range then the first monitor is used.
+    If index = -1 then all monitors are treated as one large virtual monitor.
 
-   If direction begins with 'H' or 'h', the window is horizontally centred only.
+    If index is out of range then the first monitor is used.
 
-   If direction begins with 'V' or 'v', the window is vertically centred only.
+    If direction begins with 'H' or 'h', the window is horizontally centred only.
 
-   If centring only along one axis, the window may be moved along the other
-   axis to ensure that it is on the specified monitor.
+    If direction begins with 'V' or 'v', the window is vertically centred only.
 
-   The defaults are index = -1 (all monitors), direction = '' (both axes).
+    If centring only along one axis, the window may be moved along the other
+    axis to ensure that it is on the specified monitor.
 
-   (Available without parameters from version 0.26)
-   (Parameters and ‘centre’ available from version 0.44)
+    The defaults are index = -1 (all monitors), direction = '' (both axes).
 
 
-```
-set_opacity(value)
-set_window_opacity(value)
-```
+**(Available without parameters from version 0.26)**
+**(Parameters and ‘centre’ available from version 0.44)**
 
-	Sets the window opacity, takes a float value, 1.0 = completely opaque,
-	0.0, completely see-through. Both set_opacity and set_window_opacity
-	will do the same thing.
-	(Available from version 0.28, set_window_opacity from 0.29)
+
+`set_opacity(value), set_window_opacity(value)`
+
+    Sets the window opacity, takes a float value, 1.0 = completely opaque,
+    0.0, completely see-through. Both set_opacity and set_window_opacity
+    will do the same thing.
+    (Available from version 0.28, set_window_opacity from 0.29)
 
 
 `set_window_type(type)`
@@ -608,10 +592,7 @@ set_window_opacity(value)
 	
 **(Available from version 0.28)**
 
-```
-focus()
-focus_window()
-```
+`focus(), focus_window()`
 
 	Focuses the current window. (Function is available from version 0.30)
 
@@ -639,11 +620,13 @@ focus_window()
 	(Available from version 0.45)
 
 `xy(x, y), xy()`
+
     Set the position of a window, or if you don't give any input, get the
-    position of a window
+    position of a window.
 
 
 `xywh(x, y, w, h), xywh()`
+
     Set the position and size of a window, or if you don't give any input, get
     the position and size of a window.
 

--- a/README.md
+++ b/README.md
@@ -554,6 +554,7 @@ The rest of the functions are used to modify the properties of the windows:
 
 
 **(Available without parameters from version 0.26)**
+
 **(Parameters and ‘centre’ available from version 0.44)**
 
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,34 @@
+```
 #
 # Copyright © 2011-2017 Andreas Rönnquist.
 # Copyright © 2019-2021 Darren Salt.
 # This file is distributed under the same license
 # as the devilspie2 package, see COPYING file.
 #
+```
 
-Devilspie 2
------------
+# Devilspie 2
 
-Devilspie 2 is based on the excellent program Devil's Pie by Ross Burton, and
-takes a folder as indata, and checks that folder for Lua scripts. These
+Devilspie 2 is based on the excellent program Devil's Pie by Ross Burton.
+It takes a folder as indata and checks that folder for Lua scripts. These
 scripts are run each time a window is opened or closed, and the rules in them
 are applied on the window.
 
 Unfortunately the rules of the original Devils Pie are not supported.
 
-If you don't give devilspie2 any folder with --folder, it will read Lua scripts
-from the folder that it gets from the GLib function g_get_user_config_dir with
-devilspie2/ added to the end - g_get_user_config_dir returns the config
+If you don't give `devilspie2` any folder with --folder, it will read Lua scripts
+from the folder that it gets from the `GLib` function `g_get_user_config_dir()` with
+devilspie2/ added to the end - `g_get_user_config_dir()` returns the config
 directory as defined in the XDG Base Directory Specification. In most cases
-would be the ~/.config/devilspie2/ folder, and this folder will be created if
-it doesn't already exist. This folder is changeable with the --folder option.
-If devilspie2 doesn't find any Lua files in the folder, it will stop execution.
+would be the `~/.config/devilspie2/` folder and this folder will be created if
+it doesn't already exist. This folder is changeable with the `--folder` option.
+If `devilspie2` doesn't find any Lua files in the folder, it will stop execution.
 
 Devilspie2 will load all the Lua files in this folder in alphabetical order.
 
-Devilspie2 takes some options:
+`devilspie2` accepts the following options:
 
+```
 -h, --help          Show help options
 
 -d, --debug         Print debug information to stdout
@@ -34,40 +36,39 @@ Devilspie2 takes some options:
 -f, --folder        From which folder should we load our Lua scripts
 -v, --version       Print program version and quit
 -w, --wnck-version  Show version of libwnck and quit
+```
 
-
-Config
--------
+## Config
 
 A config is read from the folder where we read all scripts, and is customizable
-by the --folder option. By default this folder is ~/.config/devilspie2/.
+by the `--folder` option. By default this folder is `~/.config/devilspie2/`.
 
-If there is a file named devilspie2.lua in this folder, it is read and it is
-searched for a variable (a lua table of strings) named either
-scripts_window_close, scripts_window_focus or scripts_window_blur -
+If there is a file named `devilspie2.lua` in this folder, it is read and it is
+searched for a variable (a Lua table of strings) named 
+`scripts_window_close`, `scripts_window_focus` or `scripts_window_blur`.
 The filenames in the strings in this table will be called when windows are
-closed, focused or blurred respectively. If these variables isn't present in
-this file, it will be called as a devilspie2 script file like any other.
+closed, focused or blurred respectively. If these variables aren't present in
+the file, it will be called as a `devilspie2` script file like any other.
 
 For example:
 
---
+```lue
 scripts_window_close = {
    "file1.lua",
    "file2.lua"
 }
+```
 
-This would make the files file1.lua and file2.lua interpreted when windows are
-closing instead of when windows are opening.
+This would make the files `file1.lua` and `file2.lua` interpreted when windows are
+closing.
 
 
-Scripting
----------
+## Scripting
 
 You can choose to have all script functionality in one file, or you can split
-it up into several, Devilspie2 runs on all Lua files in your requested
-devilspie2 folder, by default ~/.config/devilspie2 - that is all files with a
-.lua extension.
+it up into several, `devilspie2` runs on all Lua files in your requested
+`devilspie2` folder, by default `~/.config/devilspie2` - that is all files with a
+`.lua` extension.
 
 The scripting language used is Lua; https://see www.lua.org/
 
@@ -81,10 +82,10 @@ The following commands are recognised by the Devilspie2 Lua interpreter:
 First, a function to show some debug info
 
 
-debug_print(string)
+`debug_print(string)`
 
    Debug helper that prints a string to stdout. The string is only printed to
-   stdout if devilspie2 is run with the --debug option, otherwise nothing will
+   stdout if `devilspie2` is run with the `--debug` option, otherwise nothing will
    be printed.
 
 
@@ -94,25 +95,25 @@ Then, there are the functions to get the properties of a window, and related
 information:
 
 
-get_window_name()
+`get_window_name()`
 
-   returns a string containing the name of the current window.
-
-
-get_window_has_name()
-
-   return true or false depending on if the window has a name or not
-   (from version 0.20)
+   Returns a string containing the name of the current window.
 
 
-get_application_name()
+`get_window_has_name()`
 
-   returns the application name of the current window.
+   Return true or false depending on if the window has a name or not
+   (Available from version 0.20)
 
 
-get_process_name()
+`get_application_name()`
 
-   returns the name of the process owning the current window.
+   Returns the application name of the current window.
+
+
+`get_process_name()`
+
+   Returns the name of the process owning the current window.
 
    On (at least) Linux, the process name is read from /proc/<pid>/comm. If
    that's not possible, 'ps' is launched in a shell. For this reason, you
@@ -123,7 +124,7 @@ get_process_name()
    (Available from version 0.44)
 
 
-get_window_geometry()
+`get_window_geometry()`
 
    Returns the window geometry as four numbers - x-position, y-position,
    width and height. (from version 0.16) - for example you can do something
@@ -133,45 +134,45 @@ get_window_geometry()
 	print("X: "..x..", Y: "..y..", width: "..width..", height: "..height);
 
 
-get_window_client_geometry()
+`get_window_client_geometry()`
 
-   returns the window geometry excluding the window manager borders as four
+   Returns the window geometry excluding the window manager borders as four
    numbers, x-position, y-position, width and height. (from version 0.16) -
-	see get_window_geometry for an example on how to use this function.
+	see `get_window_geometry()` for an example on how to use this function.
 
 
-get_window_is_maximized()
-get_window_is_maximised()
+`get_window_is_maximized()`
+`get_window_is_maximised()`
 
    Returns true if the window is maximised, false otherwise. (available from
    version 0.21; -ise from 0.45)
 
 
-get_window_is_maximized_vertically()
-get_window_is_maximised_vertically()
+`get_window_is_maximized_vertically()`
+`get_window_is_maximised_vertically()`
 
    Returns true if the window is vertically maximised, false otherwise.
    (available from version 0.21; -ise from 0.45)
 
 
-get_window_is_maximized_horizontally()
-get_window_is_maximised_horizontally()
+`get_window_is_maximized_horizontally()`
+`get_window_is_maximised_horizontally()`
 
    Returns true if the window is horizontally maximised, false otherwise.
    (available from version 0.21; -ise from 0.45)
 
 
-get_window_is_decorated()
+`get_window_is_decorated()`
 
    Returns true if the window is decorated, false otherwise.
    (Available from version 0.44.)
 
 
-get_window_type()
+`get_window_type()`
 
    Returns the type of the window - The result type is a string, and can
    be one of the following:
-
+```
    "WINDOW_TYPE_NORMAL"
    "WINDOW_TYPE_DESKTOP"
    "WINDOW_TYPE_DOCK"
@@ -180,30 +181,28 @@ get_window_type()
    "WINDOW_TYPE_MENU"
    "WINDOW_TYPE_UTILITY"
    "WINDOW_TYPE_SPLASHSCREEN"
+```
+   or `WINDOW_TYPE_UNRECOGNIZED` if libwnck didn't recognise the type.
 
-   or "WINDOW_TYPE_UNRECOGNIZED" if libwnck didn't recognise the type.
+   If, for whatever reason, the function didn't have a window to work on,  
+   `WINDOW_ERROR` will be returned.
 
-   If the function for some reason didn't have a window to work on the string
-   result is "WINDOW_ERROR".
-
-   (available from version 0.21)
-
-
-get_class_instance_name()
-
-   Gets the class instance name from the WM_CLASS Property for the current
-   window. Only available on libwnck 3+, and in devilspie2 version 0.21 or
-   later.
+   (Available from version 0.21)
 
 
-get_class_group_name()
+`get_class_instance_name()`
 
-   Gets the class group name from the WM_CLASS Property for the current
-   window. Only available on libwnck 3+, and in devilspie2 version 0.45 or
-   later.
+   Gets the class instance name from the `WM_CLASS` property for the current
+   window. Only available on libwnck 3+, and from `devilspie2` version 0.21.
 
 
-get_window_property(property)
+`get_class_group_name()`
+
+   Gets the class group name from the `WM_CLASS` property for the current
+   window. Only available on libwnck 3+, and from `devilspie2` version 0.45.
+
+
+`get_window_property(property)`
 
    Returns the window property described in the property string. For a list of
    available properties, you should see the page
@@ -214,67 +213,67 @@ get_window_property(property)
    (Available from version 0.21)
 
 
-get_window_role
+`get_window_role()`
 
-   Returns a string describing the current window role of the matched window as
-   defined by it's WM_WINDOW_ROLE hint.
-
-
-get_window_xid
-
-   Returns the X window id of the current window.
+    Returns a string describing the current window role of the matched window as
+    defined by it's WM_WINDOW_ROLE hint.
 
 
-get_window_class
+`get_window_xid()`
 
-   Returns a string representing the class of the current window.
-
-
-get_workspace_count
-
-	Return the number of workspaces available (available from version 0.27)
+    Returns the X window id of the current window.
 
 
-get_screen_geometry
+`get_window_class()`
 
-	Returns the screen geometry (two numbers) for the screen of the
-	current window (available from version 0.29)
-
-
-get_window_fullscreen
-get_fullscreen
-
-	Returns TRUE if the window is fullscreen, FALSE otherwise
-	(available from version 0.32)
+    Returns a string representing the class of the current window.
 
 
-get_monitor_index
+`get_workspace_count()`
+
+    Return the number of workspaces available (available from version 0.27)
+
+
+`get_screen_geometry()`
+
+    Returns the screen geometry (two numbers) for the screen of the
+    current window (available from version 0.29)
+
+
+`get_window_fullscreen()`
+`get_fullscreen()`
+
+    Returns true if the window is fullscreen, false otherwise
+    (available from version 0.32)
+
+
+`get_monitor_index()`
 
    Returns the index of the monitor containing the window centre (or some
    part of the window).
    (Available from version 0.44)
 
 
-get_monitor_geometry
+`get_monitor_geometry()`
 
    Returns x, y, width, height for the window's monitor.
    (Available from version 0.44)
 
 
-get_monitor_geometry(index)
+`get_monitor_geometry(index)`
 
    Returns x, y, width, height for the given monitor.
    If the index is out of range, nothing is returned.
 
 
-and the rest of the commands are used to modify the properties of the windows:
+The rest of the functions are used to modify the properties of the windows:
 
 
-set_adjust_for_decoration([bool])
+`set_adjust_for_decoration([bool])`
 
    Allow for situations where moving or resizing the window is done
    incorrectly, i.e.
-      set_window_position(0,0)
+      `set_window_position(0,0)`
    results in the window decoration being taken into account twice, i.e. 
    the window (including decoration) is offset from the top left corner by
    the width of the left side decoration and the height of the title bar.
@@ -285,24 +284,25 @@ set_adjust_for_decoration([bool])
    If used, it should be used at the start of the script.
 
    This affects the following functions:
-      set_window_geometry
-      set_window_position
-      set_window_size
-      xy
-      xywh
-
+```
+      set_window_geometry()
+      set_window_position()
+      set_window_size()
+      xy()
+      xywh()
+```
    (Available from version 0.45)
 
 
-set_window_position(xpos, ypos, [index])
+`set_window_position(xpos, ypos, [index])`
 
    Set the position of a window.
 
    If index is specified then the co-ordinates are relative to a corner of
    the specified monitor (counting from 1) on the current workspace. Which
    corner is determined by the co-ordinates' signs:
-      +ve X ⇒ left, -ve X ⇒ right;
-      +ve Y ⇒ top,  -ve Y ⇒ bottom.
+      `+ve X ⇒ left, -ve X ⇒ right;`
+      `+ve Y ⇒ top,  -ve Y ⇒ bottom.`
 
    NOTE: since -0 would have a use here but is equal to +0, ~ (bitwise NOT)
    is used. To put the window 60px from the right or bottom, use ~60 or -61.
@@ -314,212 +314,212 @@ set_window_position(xpos, ypos, [index])
    If index = -1 then all monitors are treated as one large virtual monitor.
 
 
-set_window_position2(xpos, ypos)
+`set_window_position2(xpos, ypos)`
 
-   Set the position of a window - Compared to set_window_position, this
-   function uses XMoveWindow instead of wnck_window_set_geometry which
+   Set the position of a window - unlike `set_window_position()`, this
+   function uses `XMoveWindow` instead of `wnck_window_set_geometry()` which
    gives a slightly different result.
    (Available from version 0.21)
 
 
-set_window_property(property, value)
+`set_window_property(property, value)`
 
    Set a property of a window to a string or a cardinal (32-bit integer or
    boolean).
    (Available from version 0.44)
 
 
-delete_window_property(property)
+`delete_window_property(property)`
 
    Remove a property from a window.
    (Available from version 0.44)
 
 
-set_window_size (xsize, ysize)
+`set_window_size (xsize, ysize)`
 
-   Sets the size of a window - takes xsize and ysize as parameters.
+   Sets the size of a window - takes `xsize` and `ysize` as parameters.
 
 
-set_window_geometry (xpos, ypos, xsize, ysize)
+`set_window_geometry (xpos, ypos, xsize, ysize)`
 
    Sets both size and position of a window in one command. Takes four
-   parameters, xpos, ypos, xsize and ysize.
+   parameters, `xpos`, `ypos`, `xsize` and `ysize`.
 
 
-set_window_geometry2 (xpos, ypos, xsize, ysize)
+`set_window_geometry2 (xpos, ypos, xsize, ysize)`
 
-   Sets the window geometry just as set_window_geometry, using
-   XMoveResizeWindow instead of its libwnck alternative. This results in
-   different coordinates than the set_window_geometry function, and results
-   are more similar to the results of the original devilspie geometry function.
+   Sets the window geometry just as `set_window_geometry()`, using
+   `XMoveResizeWindow()` instead of its `libwnck` alternative. This results in
+   different coordinates than the `set_window_geometry()` function, and results
+   are more similar to the results of the original `devilspie` geometry function.
    (available from version 0.21)
 
 
-shade()
+`shade()`
 
    "Shades" a window, showing only the title-bar.
 
 
-unshade()
+`unshade()`
 
-   Unshades a window - the opposite of "shade"
+   Un-shades a window - the opposite of "shade"
 
 
-maximize()
-maximise()
+`maximize()`
+`maximise()`
 
-   maximises a window
+   Maximises a window
    (-ise from 0.45)
 
 
-unmaximize()
-unmaximise()
+`unmaximize()`
+`unmaximise()`
 
-   unmaximises a window
+   Un-maximises a window
    (-ise from 0.45)
 
 
-maximize_vertically()
-maximise_vertically()
+`maximize_vertically()`
+`maximise_vertically()`
 
-   maximises the current window vertically.
+   Maximises the current window vertically.
    (-ise from 0.45)
 
 
-maximize_horizontally()
-maximise_horizontally()
+`maximize_horizontally()`
+`maximise_horizontally()`
 
-   maximises the current window horizontally.
+   Maximises the current window horizontally.
    (-ise from 0.45)
 
 
-minimize()
-minimise()
+`minimize()`
+`minimise()`
 
-   minimises a window
+   Minimises a window
    (-ise from 0.45)
 
 
-unminimize()
-unminimise()
+`unminimize()`
+`unminimise()`
 
-   unminimises a window, that is bringing it back to screen from the minimised
+   Un-minimises a window, that is bringing it back to screen from the minimised
    position/size.
    (-ise from 0.45)
 
 
-decorate_window()
+`decorate_window()`
 
    Shows all window decoration.
 
 
-undecorate_window()
+`undecorate_window()`
 
    Removes all window decorations.
 
 
-close_window()
+`close_window()`
 
 	Closes the window. (Available from 0.31)
 
 
-set_window_workspace(number)
+`set_window_workspace(number)`
 
    Moves a window to another workspace. The number variable starts counting at
    1.
 
 
-change_workspace(number)
+`change_workspace(number)`
 
    Changes the current workspace to another. The number variable starts counting
    at 1.
 
 
-pin_window()
+`pin_window()`
 
-   asks the window manager to put the window on all workspaces.
+   Asks the window manager to put the window on all workspaces.
 
 
-unpin_window()
+`unpin_window()`
 
    Asks the window manager to put window only in the currently active workspace.
 
 
-stick_window()
+`stick_window()`
 
    Asks the window manager to keep the window's position fixed on the screen,
    even when the workspace or viewport scrolls.
 
 
-unstick_window()
+`unstick_window()`
 
    Asks the window manager to not have window's position fixed on the screen
    when the workspace or viewport scrolls.
 
 
-set_skip_tasklist(skip)
+`set_skip_tasklist(skip)`
 
    Set this to true if you would like the window to skip listing in your
    tasklist. Takes a boolean(true or false) as value. (from version 0.16)
 
 
-set_skip_pager(skip)
+`set_skip_pager(skip)`
 
    Set this to true if you would like the window to skip listing in your pager.
    Takes a boolean(true or false) as value. (from version 0.16)
 
 
-set_window_above([above])
+`set_window_above([above])`
 
    Set the current window above all normal windows. (available from version
    0.21)
    Optionally takes a boolean(true or false) as value.
 
-   make_always_on_top() is the same as set_window_above(true).
+  `make_always_on_top()` is the same as `set_window_above(true)`.
 
 
-set_on_top()
+`set_on_top()`
 
    sets a window on top of the others.
-   Unlike set_window_above, it doesn't lock the window in this position.
+   Unlike `set_window_above()`, it doesn't lock the window in this position.
    As of version 0.45, the window's layer (above, between, below) is
    maintained.
 
 
-set_window_below([below])
+`set_window_below([below])`
 
    Set the current window below all normal windows. (available from version
    0.21)
    Optionally takes a boolean(true or false) as value.
 
 
-set_on_bottom()
+`set_on_bottom()`
 
-   sets a window below the others.
-   Unlike set_window_below, it doesn't lock the window in this position.
+   Sets a window below the others.
+   Unlike `set_window_below()`, it doesn't lock the window in this position.
    (Available from version 0.45.)
 
 
-set_window_fullscreen(fullscreen)
+`set_window_fullscreen(fullscreen)`
 
    Asks the window manager to set the fullscreen state of the window according
    to the fullscreen boolean. (available from version 0.24)
 
 
-set_viewport(viewport)
+`set_viewport(viewport)`
 
    Using one indata, moves the window to the requested viewport - Counting
 	starts at number 1. (Available from version 0.25)
 	- Also see the alternative usage of this function below.
 
-set_viewport(x, y)
+`set_viewport(x, y)`
 
 	If you are using two indata to the set_viewport function, you can decide
 	where in the viewport the window will be placed.
 	(Available from version 0.40)
 
-center([index,] [direction])
-centre([index,] [direction])
+`center([index,] [direction])`
+`centre([index,] [direction])`
 
    With no parameters, centres the current window on the current workspace.
    May place the window across multiple monitors.
@@ -548,8 +548,8 @@ centre([index,] [direction])
    (Parameters and ‘centre’ available from version 0.44)
 
 
-set_opacity(value)
-set_window_opacity(value)
+`set_opacity(value)`
+`set_window_opacity(value)`
 
 	Sets the window opacity, takes a float value, 1.0 = completely opaque,
 	0.0, completely see-through. Both set_opacity and set_window_opacity
@@ -557,11 +557,11 @@ set_window_opacity(value)
 	(Available from version 0.28, set_window_opacity from 0.29)
 
 
-set_window_type(type)
+`set_window_type(type)`
 
-	Sets the window type, according to _NET_WM_WINDOW_TYPE. The allowed types
-	are the standard _NET_WM ones (formatted as a string):
-
+	Sets the window type, according to `_NET_WM_WINDOW_TYPE`. The allowed types
+	are the standard `_NET_WM` ones (formatted as a string):
+```
 	"_NET_WM_WINDOW_TYPE_DESKTOP"
 	"_NET_WM_WINDOW_TYPE_DOCK"
 	"_NET_WM_WINDOW_TYPE_TOOLBAR"
@@ -570,9 +570,9 @@ set_window_type(type)
 	"_NET_WM_WINDOW_TYPE_SPLASH"
 	"_NET_WM_WINDOW_TYPE_DIALOG"
 	"_NET_WM_WINDOW_TYPE_NORMAL"
-
+```
 	or shorter versions of the same values
-
+```
 	"WINDOW_TYPE_DESKTOP"
 	"WINDOW_TYPE_DOCK"
 	"WINDOW_TYPE_TOOLBAR"
@@ -581,16 +581,16 @@ set_window_type(type)
 	"WINDOW_TYPE_SPLASH"
 	"WINDOW_TYPE_DIALOG"
 	"WINDOW_TYPE_NORMAL"
-
+```
 	(Function is available from version 0.28)
 
-focus()
-focus_window()
+`focus()`
+`focus_window()`
 
 	Focuses the current window. (Function is available from version 0.30)
 
 
-set_window_strut(left, right, top, bottom, ...)
+`set_window_strut(left, right, top, bottom, ...)`
 
 	Set the reserved area at the borders of the desktop for a docking area such
 	as a taskbar or a panel. Will handle up to 12 values.
@@ -601,7 +601,7 @@ set_window_strut(left, right, top, bottom, ...)
 
 	(Available from version 0.32)
 
-get_window_strut()
+`get_window_strut()`
 
 	Get the reserved area at the borders of the desktop for a docking
 	area such as a taskbar or a panel.
@@ -612,12 +612,12 @@ get_window_strut()
 
 	(Available from version 0.45)
 
-xy(x, y), xy()
+`xy(x, y), xy()`
     Set the position of a window, or if you don't give any input, get the
     position of a window
 
 
-xywh(x, y, w, h), xywh()
+`xywh(x, y, w, h), xywh()`
     Set the position and size of a window, or if you don't give any input, get
     the position and size of a window.
 
@@ -626,11 +626,9 @@ Please note that strings comparisons are case sensitive, comparing
 "SomeProgram" with "someprogram" will not report equality.
 
 
-Simple script example
----------------------
+## Simple script example
 
-
----------------------8<---------------------
+```lua
 
 -- the debug_print command does only print anything to stdout
 -- if devilspie2 is run using the --debug option
@@ -650,29 +648,25 @@ if (get_application_name() == "Firefox") then
    maximise();
 end
 
---------------------->8---------------------
+```
 
+## Translations
 
-Translations
-------------
-
-Devilspie2 is translatable using gettext - see README.translators for more
+`devilspie2` is translatable using `gettext` - see README.translators for more
 information.
 
 
-Authors
--------
+## Authors
 
-see the AUTHORS file
+See [AUTHORS](./AUTHORS)
 
 
-Contact
--------
+## Contact
 
 Author: Darren Salt
 Homepage: http://www.nongnu.org/devilspie2
 Contact, Mailing list: devilspie2-discuss@nongnu.org,
-             https://lists.nongnu.org/mailman/listinfo/devilspie2-discuss
+        https://lists.nongnu.org/mailman/listinfo/devilspie2-discuss
 See also: https://github.com/dsalt/devilspie
 
 IRC: #devilspie2 on irc.libera.chat

--- a/src/config.c
+++ b/src/config.c
@@ -213,6 +213,9 @@ int load_config(gchar *filename)
 		event_lists[W_FOCUS] = get_table_of_strings(config_lua_state,
 		                         script_folder,
 		                         "scripts_window_focus");
+		event_lists[W_TITLE_CHANGE] = get_table_of_strings(config_lua_state,
+		                         script_folder,
+		                         "scripts_window_title_change");
 		event_lists[W_BLUR]  = get_table_of_strings(config_lua_state,
 		                         script_folder,
 		                         "scripts_window_blur");

--- a/src/config.h
+++ b/src/config.h
@@ -30,6 +30,7 @@ typedef enum {
 	W_OPEN,
 	W_CLOSE,
 	W_FOCUS,
+	W_TITLE_CHANGE,
 	W_BLUR,
 	W_NUM_EVENTS /* keep this at the end */
 } win_event_type;


### PR DESCRIPTION
- Implement window title chnage hook (window signal `name-changed`)
- Format as MD and minor revisions

Only issue is the `name-changed` signal is often (though not always) emitted twice. Could you see if you can reproduce on your system?

Tested on:
> Debian GNU/Linux trixie/sid

with:
```
libgtk-3-0t64:amd64          3.24.41-4
libwnck-3-0:amd64     43.0-3+b1
libglib2.0-0t64:amd64             2.78.4-7
liblua5.4-0:amd64   5.4.6-3+b1
```
(though the double firing is not at the Lua level)