### PR TITLE
Allow the passing of a workspace name into the LUA functions set_window_workspace() and change_workspace()

### DIFF
--- a/README
+++ b/README
@@ -423,16 +423,14 @@ close_window()
 	Closes the window. (Available from 0.31)
 
 
-set_window_workspace(number)
+set_window_workspace(number or string)
 
-   Moves a window to another workspace. The number variable starts counting at
-   1.
+   Moves a window to another workspace, Indicated as a 1-based number, or a workspace name.
 
 
-change_workspace(number)
+change_workspace(number or string)
 
-   Changes the current workspace to another. The number variable starts counting
-   at 1.
+   Changes the current workspace to another, Indicated as a 1-based number, or a workspace name.
 
 
 pin_window()

--- a/src/script_functions.h
+++ b/src/script_functions.h
@@ -23,6 +23,10 @@
 /**
  *
  */
+#include "lua.h"
+#define WNCK_I_KNOW_THIS_IS_UNSTABLE
+#include "libwnck/libwnck.h"
+
 int c_get_window_name(lua_State *lua);
 int c_get_window_has_name(lua_State *lua);
 
@@ -71,7 +75,7 @@ int c_close_window(lua_State *lua);
 void set_current_window(WnckWindow *window);
 WnckWindow *get_current_window();
 
-int c_set_adjust_for_decoration();
+int c_set_adjust_for_decoration(lua_State *lua);
 
 int c_get_window_geometry(lua_State *lua);
 int c_get_window_client_geometry(lua_State *lua);


### PR DESCRIPTION
Simply allows a name to be used from the LUA scripts as well as a number.

The name must match exactly with that of the workspace, including case.
The search is linear by workspace index and the first found will be returned.

btw: Did you know that your repo is being used in the Arch Linux AUR?
