### PR TITLE
Allow rules to be run when a window name/title changes

### DIFF
--- a/README
+++ b/README
@@ -43,11 +43,14 @@ A config is read from the folder where we read all scripts, and is customizable
 by the --folder option. By default this folder is ~/.config/devilspie2/.
 
 If there is a file named devilspie2.lua in this folder, it is read and it is
-searched for a variable (a lua table of strings) named either
-scripts_window_close, scripts_window_focus or scripts_window_blur -
-The filenames in the strings in this table will be called when windows are
-closed, focused or blurred respectively. If these variables isn't present in
-this file, it will be called as a devilspie2 script file like any other.
+searched for a variable (a lua table of strings) named:
+* scripts_window_close
+* scripts_window_focus
+* scripts_window_blur
+* scripts_window_name_change
+The filenames in the strings in this table will be called when the respective
+events occur. If these variables aren't present in this file, it will be called
+as a devilspie2 script file like any other.
 
 For example:
 

--- a/src/config.c
+++ b/src/config.c
@@ -38,12 +38,13 @@
 /**
  *
  */
-GSList *event_lists[W_NUM_EVENTS] = { NULL, NULL, NULL, NULL };
+GSList *event_lists[W_NUM_EVENTS] = { NULL, NULL, NULL, NULL, NULL };
 const char *const event_names[W_NUM_EVENTS] = {
 	"window_open",
 	"window_close",
 	"window_focus",
 	"window_blur",
+	"window_name_change",
 };
 
 
@@ -216,6 +217,9 @@ int load_config(gchar *filename)
 		event_lists[W_BLUR]  = get_table_of_strings(config_lua_state,
 		                         script_folder,
 		                         "scripts_window_blur");
+		event_lists[W_NAME_CHANGED] = get_table_of_strings(config_lua_state,
+		                         script_folder,
+		                         "scripts_window_name_change");
 	}
 
 	// add the files in the folder to our linked list

--- a/src/config.h
+++ b/src/config.h
@@ -19,9 +19,8 @@
 #ifndef __HEADER_CONFIG_
 #define __HEADER_CONFIG_
 
-/**
- *
- */
+#include "glib.h"
+
 int load_config(gchar *config_filename);
 
 void clear_file_lists();
@@ -31,6 +30,7 @@ typedef enum {
 	W_CLOSE,
 	W_FOCUS,
 	W_BLUR,
+	W_NAME_CHANGED,
 	W_NUM_EVENTS /* keep this at the end */
 } win_event_type;
 

--- a/src/devilspie2.c
+++ b/src/devilspie2.c
@@ -101,12 +101,25 @@ static void load_list_of_scripts(WnckScreen *screen G_GNUC_UNUSED, WnckWindow *w
 }
 
 
+static void window_name_changed_cb(WnckWindow *window)
+{
+	WnckScreen * screen = wnck_window_get_screen(window);
+	if(screen == NULL) return;
+
+	load_list_of_scripts(screen, window, event_lists[W_NAME_CHANGED]);
+}
+
 /**
  *
  */
 static void window_opened_cb(WnckScreen *screen, WnckWindow *window)
 {
 	load_list_of_scripts(screen, window, event_lists[W_OPEN]);
+	/*
+	Attach a listener to each window for window-specific changes
+	Safe to do this way as long as the 'user data' parameter is NULL
+	*/
+	g_signal_connect(window, "name-changed", (GCallback)window_name_changed_cb, NULL);
 }
 
 


### PR DESCRIPTION
The Existing 3 event types aren't quite enough if, for example you have multiple browser windows open, and want them to be on different workspaces.  At the point the windows are opened they will have a generic name. Attaching a listener for "name-changed" to each window as they are opened allows these changes to be caught (and acted upon) reliably.