### PR TITLE
Refactor param count checking and errors

### DIFF
--- a/po/devilspie2.pot
+++ b/po/devilspie2.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: devilspie2 0.44\n"
-"Report-Msgid-Bugs-To: andreas@ronnquist.net\n"
-"POT-Creation-Date: 2021-09-05 01:53+0100\n"
+"Project-Id-Version: devilspie2 0.45\n"
+"Report-Msgid-Bugs-To: devspam@moreofthesa.me.uk\n"
+"POT-Creation-Date: 2024-10-04 23:09-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,151 +17,174 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: config.c:192
+#: config.c:193
 msgid "script_folder isn't a folder."
 msgstr ""
 
-#: config.c:203 script.c:249
+#: config.c:204 script.c:257
 #, c-format
 msgid "Error: %s\n"
 msgstr ""
 
-#: devilspie2.c:180
+#: devilspie2.c:195
 msgid "Received signal:"
 msgstr ""
 
-#: devilspie2.c:231
+#: devilspie2.c:244
 #, c-format
 msgid "List of Lua files handling \"%s\" events in folder:"
 msgstr ""
 
-#: devilspie2.c:241
+#: devilspie2.c:254
 msgid "No script files found in the script folder - exiting."
 msgstr ""
 
-#: devilspie2.c:306
+#: devilspie2.c:319
 msgid "Print debug info to stdout"
 msgstr ""
 
-#: devilspie2.c:309
+#: devilspie2.c:322
 msgid "Don't apply any rules, only emulate execution"
 msgstr ""
 
-#: devilspie2.c:312
+#: devilspie2.c:325
 msgid "Search for scripts in this folder"
 msgstr ""
 
-#: devilspie2.c:312
+#: devilspie2.c:325
 msgid "FOLDER"
 msgstr ""
 
-#: devilspie2.c:315
+#: devilspie2.c:328
 msgid "Show Devilspie2 version and quit"
 msgstr ""
 
-#: devilspie2.c:321
+#: devilspie2.c:333
 msgid "Show libwnck version and quit"
 msgstr ""
 
-#: devilspie2.c:338
+#: devilspie2.c:348
 msgid "apply rules on windows"
 msgstr ""
 
-#: devilspie2.c:345
+#: devilspie2.c:355
 #, c-format
 msgid "option parsing failed: %s"
 msgstr ""
 
-#: devilspie2.c:368
+#: devilspie2.c:378
 msgid "Couldn't create the default folder for devilspie2 scripts."
 msgstr ""
 
-#: devilspie2.c:394
+#: devilspie2.c:412
 msgid "An X11 display is required for devilspie2."
 msgstr ""
 
-#: devilspie2.c:401
+#: devilspie2.c:419
 msgid "Couldn't init script error messages!"
 msgstr ""
 
-#: devilspie2.c:421
+#: devilspie2.c:439
 msgid "Running devilspie2 in debug and emulate mode."
 msgstr ""
 
-#: devilspie2.c:423
+#: devilspie2.c:441
 msgid "Running devilspie2 in debug mode."
 msgstr ""
 
-#: devilspie2.c:426
+#: devilspie2.c:444
 #, c-format
 msgid "Using scripts from folder: %s"
 msgstr ""
 
-#: devilspie2.c:442
+#: devilspie2.c:460
 msgid "Couldn't create directory monitor!"
 msgstr ""
 
-#: script_functions.c:736 script_functions.c:782
+#: script_functions.c:963 script_functions.c:1016
+#, c-format
+msgid "A Workspace with the name '%s' does not exist!"
+msgstr ""
+
+#: script_functions.c:976 script_functions.c:1028
 #, c-format
 msgid "Workspace number %d does not exist!"
 msgstr ""
 
-#: script_functions.c:1883
-msgid "Could not get workspace"
-msgstr ""
-
-#: xutils.c:189 xutils.c:207 error_strings.c:135
+#: xutils.c:195 xutils.c:213 error_strings.c:85
 msgid "Failed!"
 msgstr ""
 
-#: error_strings.c:53
+#: xutils.c:733
+msgid "Could not get workspace"
+msgstr ""
+
+#: error_strings.c:52
 msgid "Couldn't allocate error string!"
 msgstr ""
 
-#: error_strings.c:55
+#: error_strings.c:63
 msgid "No indata expected"
 msgstr ""
 
-#: error_strings.c:61
+#: error_strings.c:64
 msgid "One indata expected"
 msgstr ""
 
-#: error_strings.c:67
+#: error_strings.c:65
 msgid "Two indata expected"
 msgstr ""
 
-#: error_strings.c:73
+#: error_strings.c:66
+msgid "Three indata expected"
+msgstr ""
+
+#: error_strings.c:67
 msgid "Four indata expected"
 msgstr ""
 
-#: error_strings.c:79
-msgid "One or two indata expected"
+#: error_strings.c:69
+#, c-format
+msgid "%d or %d indata expected"
 msgstr ""
 
-#: error_strings.c:86
+#: error_strings.c:70
+#, c-format
+msgid "%d to %d indata expected"
+msgstr ""
+
+#: error_strings.c:72
+msgid "At least four indata expected"
+msgstr ""
+
+#: error_strings.c:74
 msgid "Number expected as indata"
 msgstr ""
 
-#: error_strings.c:93
+#: error_strings.c:75
 msgid "Boolean expected as indata"
 msgstr ""
 
-#: error_strings.c:100
+#: error_strings.c:76
 msgid "String expected as indata"
 msgstr ""
 
-#: error_strings.c:107
+#: error_strings.c:78
 msgid "Number or string expected as indata"
 msgstr ""
 
-#: error_strings.c:115
+#: error_strings.c:79
+msgid "Number or string or boolean expected as indata"
+msgstr ""
+
+#: error_strings.c:81
 msgid "Integer greater than zero expected"
 msgstr ""
 
-#: error_strings.c:122
+#: error_strings.c:82
 msgid "Could not find current viewport"
 msgstr ""
 
-#: error_strings.c:129
+#: error_strings.c:83
 msgid "Setting viewport failed"
 msgstr ""

--- a/src/error_strings.c
+++ b/src/error_strings.c
@@ -24,21 +24,20 @@
 
 #include "error_strings.h"
 
+const int max_indata_expected;
+gchar *num_indata_expected_errors[] = {NULL, NULL, NULL, NULL, NULL};
 
-gchar *no_indata_expected_error = NULL;
-gchar *one_indata_expected_error = NULL;
-gchar *two_indata_expected_error = NULL;
-gchar *four_indata_expected_error = NULL;
+gchar *n_or_m_indata_expected_error = NULL;
+gchar *n_to_m_indata_expected_error = NULL;
 
-gchar *one_or_two_indata_expected_error = NULL;
-gchar *two_or_three_indata_expected_error = NULL;
+gchar *at_least_four_indata_expected_error = NULL;
 
 gchar *number_expected_as_indata_error = NULL;
 gchar *boolean_expected_as_indata_error = NULL;
-
 gchar *string_expected_as_indata_error = NULL;
 
 gchar *number_or_string_expected_as_indata_error = NULL;
+gchar *number_or_string_or_boolean_expected_as_indata_error = NULL;
 
 gchar *integer_greater_than_zero_expected_error = NULL;
 gchar *could_not_find_current_viewport_error = NULL;
@@ -54,26 +53,30 @@ gchar *failed_string = NULL;
 #define INIT_ERRMSG(errvar, errtxt) \
 	{ \
 		errvar = g_strdup(errtxt); \
-		if (!no_indata_expected_error) { \
-			printf("%s\n", ALLOCATE_ERROR_STRING); \
+		if (!errvar) { \
+			printf("%s: \"%s\"\n", ALLOCATE_ERROR_STRING, errtxt); \
 			return -1; \
 		} \
 	}
 int init_script_error_messages()
 {
-	INIT_ERRMSG(no_indata_expected_error,                   _("No indata expected"));
-	INIT_ERRMSG(one_indata_expected_error,                  _("One indata expected"));
-	INIT_ERRMSG(two_indata_expected_error,                  _("Two indata expected"));
-	INIT_ERRMSG(four_indata_expected_error,                 _("Four indata expected"));
+	INIT_ERRMSG(num_indata_expected_errors[0],              _("No indata expected"));
+	INIT_ERRMSG(num_indata_expected_errors[1],              _("One indata expected"));
+	INIT_ERRMSG(num_indata_expected_errors[2],              _("Two indata expected"));
+	INIT_ERRMSG(num_indata_expected_errors[3],              _("Three indata expected"));
+	INIT_ERRMSG(num_indata_expected_errors[4],              _("Four indata expected"));
 
-	INIT_ERRMSG(one_or_two_indata_expected_error,           _("One or two indata expected"));
-	INIT_ERRMSG(two_or_three_indata_expected_error,         _("Two or three indata expected"));
+	INIT_ERRMSG(n_or_m_indata_expected_error,               _("%d or %d indata expected"));
+	INIT_ERRMSG(n_to_m_indata_expected_error,               _("%d to %d indata expected"));
+
+	INIT_ERRMSG(at_least_four_indata_expected_error,        _("At least four indata expected"));
 
 	INIT_ERRMSG(number_expected_as_indata_error,            _("Number expected as indata"));
 	INIT_ERRMSG(boolean_expected_as_indata_error,           _("Boolean expected as indata"));
 	INIT_ERRMSG(string_expected_as_indata_error,            _("String expected as indata"));
 
 	INIT_ERRMSG(number_or_string_expected_as_indata_error,  _("Number or string expected as indata"));
+	INIT_ERRMSG(number_or_string_or_boolean_expected_as_indata_error,  _("Number or string or boolean expected as indata"));
 
 	INIT_ERRMSG(integer_greater_than_zero_expected_error,   _("Integer greater than zero expected"));
 	INIT_ERRMSG(could_not_find_current_viewport_error,      _("Could not find current viewport"));
@@ -90,19 +93,21 @@ int init_script_error_messages()
  */
 void done_script_error_messages()
 {
-	g_free(no_indata_expected_error);
-	g_free(one_indata_expected_error);
-	g_free(two_indata_expected_error);
-	g_free(four_indata_expected_error);
+	for (int i = 0; i <= max_indata_expected; i++) {
+		g_free(num_indata_expected_errors[i]);
+	}
 
-	g_free(one_or_two_indata_expected_error);
-	g_free(two_or_three_indata_expected_error);
+	g_free(n_or_m_indata_expected_error);
+	g_free(n_to_m_indata_expected_error);
+
+	g_free(at_least_four_indata_expected_error);
 
 	g_free(number_expected_as_indata_error);
 	g_free(boolean_expected_as_indata_error);
 	g_free(string_expected_as_indata_error);
 
 	g_free(number_or_string_expected_as_indata_error);
+	g_free(number_or_string_or_boolean_expected_as_indata_error);
 
 	g_free(integer_greater_than_zero_expected_error);
 	g_free(could_not_find_current_viewport_error);

--- a/src/error_strings.h
+++ b/src/error_strings.h
@@ -23,20 +23,20 @@
 /**
  *
  */
-extern gchar *no_indata_expected_error;
-extern gchar *one_indata_expected_error;
-extern gchar *two_indata_expected_error;
-extern gchar *four_indata_expected_error;
+extern const int max_indata_expected;
+extern gchar *num_indata_expected_errors[];
 
-extern gchar *one_or_two_indata_expected_error;
-extern gchar *two_or_three_indata_expected_error;
+extern gchar *n_or_m_indata_expected_error;
+extern gchar *n_to_m_indata_expected_error;
+
+extern gchar *at_least_four_indata_expected_error;
 
 extern gchar *number_expected_as_indata_error;
 extern gchar *boolean_expected_as_indata_error;
-
 extern gchar *string_expected_as_indata_error;
 
 extern gchar *number_or_string_expected_as_indata_error;
+extern gchar *number_or_string_or_boolean_expected_as_indata_error;
 
 extern gchar *integer_greater_than_zero_expected_error;
 extern gchar *could_not_find_current_viewport_error;


### PR DESCRIPTION
This PR deduplicates the checking of the stack size in all of the `c_` functions registered with lua. A few inconsistencies and bugs were fixed along the way.

This involved a bit of a refactor for how error messages work, which will require some new translations. Let me know if you want me to add machine translation of the new text to this PR? Also I think the .pot file wasn't re-generated for some other recent code changes.

I also changed a few error types where the code was producing "Four indata expected" when one of four indata had the wrong type, now it's producing "[correct type] expected as indata" which I think is more appropriate.