### PR TITLE
Documenting use of sleep to defer actions briefly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,7 +746,9 @@ And the rest of the commands are used to modify the properties of the windows:
   <a name="focus" />
 
 
-### Simple script example
+### Simple script examples
+
+**Showing debug output and resizing and maximisation of specific windows:**
 
 ```lua
 -- the debug_print command only prints to stdout
@@ -766,6 +768,30 @@ end
 if (get_application_name() == "Firefox") then
    maximise()
 end
+```
+
+**Showing handling of conflict between `devilspie2` and other programs (in this case,
+`emacs`):**
+
+This example uses [millisleep](#user-content-millisleep) to enforce a short
+delay.
+
+```lua
+-- Make Emacs (emacs or emacs-gtk) always start maximised.
+win_class = get_class_instance_name()
+
+debug_print("Window class: " .. win_class)
+
+if win_class == "emacs" or win_class == "Emacs" then
+  millisleep(100)
+  -- Emacs applies default window size etc. after a brief delay,
+  -- potentially overriding devilspie2.
+  --
+  -- A brief pause (here, of 0.1s) ensures that devilspie2's actions on the
+  -- window take effect after Emacs completes its initialisation.
+  maximise()
+end
+
 ```
 
 ## Translations

--- a/README.md
+++ b/README.md
@@ -788,8 +788,8 @@ if win_class == "emacs" or win_class == "Emacs" then
   --
   -- A brief pause (here, of 0.1s) ensures that devilspie2's actions on the
   -- window take effect after Emacs completes its initialisation. A shorter
-  -- pause may work, or a longer one may be needed. Experiment; in this
-  -- case, 'millisleep(10)' (0.01s) seems fine for most modern PCs.
+  -- pause may work, or a longer one may be needed. Experiment! Could be
+  -- that 'millisleep(10)' (0.01s) works well on one PC…?
   --
   -- If you prefer, you can have Emacs maximise its window (as in this
   -- example) via one of its configuration files - early-init.el, which is

--- a/README.md
+++ b/README.md
@@ -712,7 +712,7 @@ And the rest of the commands are used to modify the properties of the windows:
   Sleep for a number of milliseconds, between 1 and 1000 (1 second).
 
   This is a convenience function so that you don't have to use `os.execute`
-  (to run `sleep`) or `posix.nanosleep`.
+  (to run `sleep`) or (from LuaPosix) `posix.nanosleep`.
 
   *(Available from version 0.46)*
 
@@ -796,6 +796,13 @@ if win_class == "emacs" or win_class == "Emacs" then
   -- normally faster (and avoids a possible visual effect), or init.el –
   -- using this LISP statement:
   --   (push '(fullscreen .  maximized) default-frame-alist)
+  --
+  -- 'millisleep' is new to 0.46. The 0.1s delay for older versions:
+  --   option 1:
+  --     os.execute("sleep 0.1")
+  --   option 2 (needs luaposix):
+  --     posix = require "posix"
+  --     posix.nanosleep(0, 100e6)
   millisleep(100)
   maximise()
 end

--- a/README.md
+++ b/README.md
@@ -801,8 +801,8 @@ if win_class == "emacs" or win_class == "Emacs" then
   --   option 1:
   --     os.execute("sleep 0.1")
   --   option 2 (needs luaposix):
-  --     posix = require "posix"
-  --     posix.nanosleep(0, 100e6)
+  --     nanosleep = require "posix.time".nanosleep
+  --     nanosleep{tv_nsec=100e6}
   millisleep(100)
   maximise()
 end

--- a/README.md
+++ b/README.md
@@ -783,12 +783,20 @@ win_class = get_class_instance_name()
 debug_print("Window class: " .. win_class)
 
 if win_class == "emacs" or win_class == "Emacs" then
-  millisleep(100)
   -- Emacs applies default window size etc. after a brief delay,
   -- potentially overriding devilspie2.
   --
   -- A brief pause (here, of 0.1s) ensures that devilspie2's actions on the
-  -- window take effect after Emacs completes its initialisation.
+  -- window take effect after Emacs completes its initialisation. A shorter
+  -- pause may work, or a longer one may be needed. Experiment; in this
+  -- case, 'millisleep(10)' (0.01s) seems fine for most modern PCs.
+  --
+  -- If you prefer, you can have Emacs maximise its window (as in this
+  -- example) via one of its configuration files - early-init.el, which is
+  -- normally faster (and avoids a possible visual effect), or init.el –
+  -- using this LISP statement:
+  --   (push '(fullscreen .  maximized) default-frame-alist)
+  millisleep(100)
   maximise()
 end
 


### PR DESCRIPTION
This is intended to show resolution of conflict between `devilspie2` and other programs re. actions on windows. See #11 for more info.

This pull request exists for comments & discussion, if any is needed.

