### PR TITLE
Get Window Workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ information:
   *(Available from version 0.27)*
 
 * `get_window_workspace()`
-  <a name="user-content-get-window-workspace"/>
+  <a name="user-content-get-window-workspace"></a>
 
   Returns 2 values: the index and name of the workspace the current window is on.
 


### PR DESCRIPTION
Add `get_window_workspace()` script function which returns 2 values denoting the workspace that the current window is on (Index and Name)

Includes a small fix to avoid a no-op in the implementation of `set_window_workspace()` and modifications to the README.md with optimistic mention of availability from v0.46


@dsalt This is one of a total of 5 PRs so I'm sorry for the github spam!
If you decide to accept them and would rather I group them into 1 larger PR, just let me know.

Thanks!