### PR TITLE
Get Active Workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ information:
   *(Available from version 0.27)*
 
   * `get_active_workspace`
-  <a name="user-content-get-active-workspace" />
+  <a name="user-content-get-active-workspace"></a>
 
   Returns the index and name of the active workspace
   (Obtained via the current window's Screen)


### PR DESCRIPTION
Add `get_active_workspace()` lua function which returns index and name of the active workspace.
As the active workspace isn't directly accessible from wnck it's obtained via the current
window's screen.

Includes modifications to the README.md and optimistic mention of availability from v0.46


@dsalt This is one of a total of 5 PRs so I'm sorry for the github spam!
If you decide to accept them and would rather I group them into 1 larger PR, just let me know.

Thanks!