### PR TITLE
Get Workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,28 @@ information:
 
   *(Available from version 0.27)*
 
+* `get_workspaces()`
+  <a name="user-content-get-workspaces"></a>
+
+  Returns 2 tables listing currently known workspaces (by Name and ID).
+  i.e. For 3 workspaces "First space", "Second" & "Third and final" and IDs of 1, 2 & 3 the returned tables
+  would be:
+  ```lua
+  local by_name, by_id = get_workspaces()
+  by_name = {
+    "First space" = 1,
+    "Second" = 2,
+    "Third and final" = 3
+  }
+  by_id = {
+    "First space", "Second", "Third and final"
+  }
+  by_name["First space"] == 1
+  by_id[3] == "Third and final"
+  ```
+    
+  *(Available from version 0.46)*
+
 * `get_screen_geometry()`
   <a name="user-content-get-screen-geometry" />
 

--- a/src/script.c
+++ b/src/script.c
@@ -115,6 +115,7 @@ register_cfunctions(lua_State *lua)
 	DP2_REGISTER(lua, set_window_workspace);
 	DP2_REGISTER(lua, change_workspace);
 	DP2_REGISTER(lua, get_workspace_count);
+	DP2_REGISTER(lua, get_workspaces);
 
 	DP2_REGISTER(lua, pin_window);
 	DP2_REGISTER(lua, unpin_window);

--- a/src/script_functions.c
+++ b/src/script_functions.c
@@ -1071,6 +1071,57 @@ int c_get_workspace_count(lua_State *lua)
 	return 1;
 }
 
+/**
+ * Returns 2 tables listing all workspaces, keyed by name, keyed by Id
+ * If workspaces cannot be obtained, 2 empty tables will be returned
+ */
+int c_get_workspaces(lua_State *lua)
+{
+	WnckWindow *window = get_current_window();
+	if(window == NULL) {
+		lua_newtable(lua);
+		lua_newtable(lua);
+		return 2;
+	}
+	
+	WnckScreen *screen = wnck_window_get_screen(window);
+	if(screen == NULL) {
+		lua_newtable(lua);
+		lua_newtable(lua);
+		return 2;
+	}
+
+	GList * workspaces = wnck_screen_get_workspaces(screen);
+	GList * workspaces_id = workspaces;
+
+	// Keyed on name
+	lua_newtable(lua);
+	while (workspaces) {
+		WnckWorkspace *workspace = workspaces->data;
+		const char * name = wnck_workspace_get_name(workspace);
+		int id = wnck_workspace_get_number(workspace) + 1;
+		lua_pushinteger(lua, id);
+		lua_setfield(lua, -2, name);
+		
+		workspaces = workspaces->next;
+	}
+
+	// Keyed on ID 
+	lua_newtable(lua);
+	workspaces = workspaces_id;
+	while (workspaces) {
+		WnckWorkspace *workspace = workspaces->data;
+		const char * name = wnck_workspace_get_name(workspace);
+		int id = wnck_workspace_get_number(workspace) + 1;
+		lua_pushstring(lua, name);
+		lua_rawseti(lua, -2, id);
+
+		workspaces = workspaces->next;
+	}
+
+	return 2;
+}
+
 
 /**
  * Unmaximize window

--- a/src/script_functions.h
+++ b/src/script_functions.h
@@ -60,6 +60,7 @@ int c_get_window_is_decorated(lua_State *lua);
 int c_set_window_workspace(lua_State *lua);
 int c_change_workspace(lua_State *lua);
 int c_get_workspace_count(lua_State *lua);
+int c_get_workspaces(lua_State *lua);
 
 int c_unmaximize(lua_State *lua);
 int c_maximize(lua_State *lua);


### PR DESCRIPTION
Add `get_workspaces()` lua function to get the currently known workspaces, which returns 2 tables listing currently known workspaces (by Name and by ID).

Includes modifications to the README.md and optimistic mention of availability from v0.46


@dsalt This is one of a total of 5 PRs so I'm sorry for the github spam!
If you decide to accept them and would rather I group them into 1 larger PR, just let me know.

Thanks!