### PR TITLE
Implement window title change hook (window signal name-changed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ via the following variables:
 * `scripts_window_focus`
 * `scripts_window_blur`
 * `scripts_window_name_change`
+* `scripts_window_title_change`
 
 It is expected that these variables are tables containing strings. The
 files named in these tables are expected to be in the scripts folder and
@@ -72,6 +73,15 @@ scripts_window_close = {
 
 With this, both `file1.lua` and `file2.lua` will be called whenever a window
 is closed.
+
+```lua
+scripts_window_title_change = {
+    "window_title_change.lua"
+}
+```
+
+This will invoke `window_title_change.lua` when the window's title changes.
+
 
 As of v0.46, each script has 5 seconds to do its job ane exit or it will be
 unceremoniously interrupted.

--- a/src/config.c
+++ b/src/config.c
@@ -212,6 +212,9 @@ int load_config(gchar *filename)
 		event_lists[W_FOCUS] = get_table_of_strings(config_lua_state,
 		                         script_folder,
 		                         "scripts_window_focus");
+		event_lists[W_TITLE_CHANGE] = get_table_of_strings(config_lua_state,
+		                         script_folder,
+		                         "scripts_window_title_change");
 		event_lists[W_BLUR]  = get_table_of_strings(config_lua_state,
 		                         script_folder,
 		                         "scripts_window_blur");

--- a/src/config.h
+++ b/src/config.h
@@ -29,6 +29,7 @@ typedef enum {
 	W_OPEN,
 	W_CLOSE,
 	W_FOCUS,
+	W_TITLE_CHANGE,
 	W_BLUR,
 	W_NAME_CHANGED,
 	W_NUM_EVENTS /* keep this at the end */


### PR DESCRIPTION
Needed to handle events like switching tabs in your browser or X terminal (to give two examples, it applies to other situations as well, like switching between Slack channels, say).