### PR TITLE
Add GH Action (CI)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,5 +39,9 @@ jobs:
         run: sudo make install
       - name: ldd
         run: ldd $PREFIX/devilspie2
-      - name: version
+      - name: check version
         run: $PREFIX/devilspie2 -v
+      - name: check libwnck version
+        run: $PREFIX/devilspie2 -w
+      - name: check Lua version
+        run: $PREFIX/devilspie2 -l

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+---
+name: Build CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [gcc-12, gcc-13, clang-17, clang-18]
+    env:
+      PREFIX: /usr/local/bin
+      CC: ${{ matrix.compiler }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y \
+            pkg-config \
+            libglib2.0-dev \
+            liblua5.3-0-dev \
+            libwnck-3-dev \
+            libgtk-3-dev \
+            libxrandr-dev \
+            build-essential \
+            clang-17 \
+            clang-18 \
+            gcc-12 \
+            gcc-13
+      - name: CC ver
+        run: ${CC} -v
+      - name: make
+        run: make
+      - name: make install
+        run: sudo make install
+      - name: ldd
+        run: ldd $PREFIX/devilspie2
+      - name: version
+        run: $PREFIX/devilspie2 -v

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get install -y \
             pkg-config \
             libglib2.0-dev \
-            liblua5.3-0-dev \
+            liblua5.4-dev \
             libwnck-3-dev \
             libgtk-3-dev \
             libxrandr-dev \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [gcc-12, gcc-13, clang-17, clang-18]
+        compiler: [gcc-12, gcc-13]
     env:
       PREFIX: /usr/local/bin
       CC: ${{ matrix.compiler }}
@@ -27,8 +27,6 @@ jobs:
             libxrandr-dev \
             build-essential \
             gettext \
-            clang-17 \
-            clang-18 \
             gcc-12 \
             gcc-13
       - name: CC ver

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
             libgtk-3-dev \
             libxrandr-dev \
             build-essential \
+            gettext \
             clang-17 \
             clang-18 \
             gcc-12 \

--- a/INSTALL
+++ b/INSTALL
@@ -16,6 +16,7 @@ libglib2.0-dev
 liblua5.3-0-dev
 libwnck-3-dev
 libgtk-3-dev
+gettext
 libxrandr-dev (optional)
 
 On a system still using Gtk version 2, replace the wnck and gtk libs with:

--- a/src/devilspie2.c
+++ b/src/devilspie2.c
@@ -372,33 +372,6 @@ int main(int argc, char *argv[])
 		printf("\n");
 		exit(EXIT_FAILURE);
 	}
-
-	gdk_init(&argc, &argv);
-
-	g_free(full_desc_string);
-	g_free(devilspie2_description);
-
-	// if the folder is NULL, default to ~/.config/devilspie2/
-	if (script_folder == NULL) {
-
-		temp_folder = g_build_path(G_DIR_SEPARATOR_S,
-		                           g_get_user_config_dir(),
-		                           "devilspie2",
-		                           NULL);
-
-		// check if the folder does exist
-		if (!g_file_test(temp_folder, G_FILE_TEST_IS_DIR)) {
-
-			// - and if it doesn't, create it.
-			if (g_mkdir(temp_folder, 0700) != 0) {
-				printf("%s\n", _("Couldn't create the default folder for devilspie2 scripts."));
-				exit(EXIT_FAILURE);
-			}
-		}
-
-		script_folder = temp_folder;
-	}
-
 	gboolean shown = FALSE;
 	if (show_version) {
 		printf("Devilspie2 v%s\n", DEVILSPIE2_VERSION);
@@ -429,6 +402,33 @@ int main(int argc, char *argv[])
 	}
 	if (shown)
 		exit(0);
+
+	gdk_init(&argc, &argv);
+
+	g_free(full_desc_string);
+	g_free(devilspie2_description);
+
+	// if the folder is NULL, default to ~/.config/devilspie2/
+	if (script_folder == NULL) {
+
+		temp_folder = g_build_path(G_DIR_SEPARATOR_S,
+		                           g_get_user_config_dir(),
+		                           "devilspie2",
+		                           NULL);
+
+		// check if the folder does exist
+		if (!g_file_test(temp_folder, G_FILE_TEST_IS_DIR)) {
+
+			// - and if it doesn't, create it.
+			if (g_mkdir(temp_folder, 0700) != 0) {
+				printf("%s\n", _("Couldn't create the default folder for devilspie2 scripts."));
+				exit(EXIT_FAILURE);
+			}
+		}
+
+		script_folder = temp_folder;
+	}
+
 
 #if (GTK_MAJOR_VERSION >= 3)
 	if (!GDK_IS_X11_DISPLAY(gdk_display_get_default())) {


### PR DESCRIPTION
The GH action:

- Builds Devilspie 2 with GCC 12 and 13
- Once successfully done, `devilspie2` is invoked with `-v`, `-w` and `-l`

I've moved the invocation of `show_version()` (and all other `show_.*version()` functions) to the beginning of main (after arg parsing check but before `gtk_init()`) to enable them to work even when an X display is not available. 
While I've encountered it in CI context, I believe it's a good change to make in general. 

I've also added `gettext` to the list of dependencies in `INSTALL`, as make fails without it (it requires `msgfmt`).

Note that, at present, the code will not build with Clang 17 and 18, see [log](https://github.com/jessp01/devilspie2/actions/runs/13228243351/job/36921857237#step:5:87). These checks should be added once corrected. 